### PR TITLE
add NRG to translation management apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@
 - [DeepL](https://deepl.com) - high-quality text translation service
 - [Google Translate](https://translate.google.com) - text translation service
 - [Microsoft Translator](https://www.microsoft.com/en-GB/translator/) - text translation service
+- [NRG](https://github.com/nanolaba/readme-generator) - markdown template engine that generates multi-language READMEs from a single .src.md source
 
 ## 📚 Resources
 


### PR DESCRIPTION
adds NRG (nanolaba readme generator) to `apps and extensions for translation management`.

NRG is a markdown template engine that generates multi-language README files (e.g. `README.md` and `README.ru.md`) from a single `.src.md` source. it covers the documentation-i18n use case that none of the existing entries address: managing translations of project READMEs / docs alongside the codebase via `${en:'…', ru:'…'}` substitutions, file imports, and a built-in TOC widget.

- repo: https://github.com/nanolaba/readme-generator
- license: MIT (open source, free, no AI dependency)
- distribution: CLI, Maven plugin, Java library

entry follows the contribution rules: <150 chars, no trailing period, mostly lowercase, focused on the unique angle (multi-language README generation), not paid/AI/freemium.