### PR TITLE
Add i18n-convert (Rust CLI for lossless i18n format conversion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
 - [LibreTranslate](https://github.com/uav4geo/LibreTranslate) - self-hosted web application to translate texts
 - [LRM](https://github.com/nickprotop/LocalizationManager) - cross-platform CLI for managing JSON (i18next compatible) and .resx localization files
 - [Fink](https://inlang.com/m/tdozzpar/app-inlang-editor) - git-based editor in the browser that connects to your repo
+- [i18n-convert](https://github.com/i18n-agent/i18n-convert) - Rust CLI that losslessly converts between 32 i18n file formats (PO, XLIFF, Android XML, iOS Strings, xcstrings, ARB, JSON variants, YAML, RESX, TMX, and more) with explicit data-loss warnings
 
 ## Text translation services
 - [DeepL](https://deepl.com) - text translation service


### PR DESCRIPTION
Adds [i18n-convert](https://github.com/i18n-agent/i18n-convert) — a Rust CLI that converts losslessly between 32 i18n file formats. Open source (MIT), no AI involvement in the conversion logic (it's a deterministic format converter with an intermediate representation that preserves plurals, comments, translator state, and format-specific metadata).

Supported formats include: PO, XLIFF 1.2 + 2.0, Android XML, iOS Strings + stringsdict + xcstrings, ARB, RESX, TMX, SRT, Excel, Qt Linguist, Java properties, YAML Rails, JSON variants, TOML, JSON5, HJSON, NEON, INI, PHP/Laravel, Markdown, plain text, CSV, TypeScript, JavaScript, iSpring XLIFF, Adobe Captivate XML, etc.

Distribution: npm (\`@i18n-agent/i18n-convert\`), crates.io (\`i18n-convert\`), Homebrew tap, prebuilt GitHub Releases binaries for macOS / Linux / Windows.

Added under **Apps and extensions for translation management** between the existing CLI tools (Fink, LRM). Lower-cased the entry title to match the surrounding style. Single line, single link, no AI marketing fluff.