### PR TITLE
Add WhisperSubTranslate

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
 - [LibreTranslate](https://github.com/uav4geo/LibreTranslate) - self-hosted web application to translate texts
 - [LRM](https://github.com/nickprotop/LocalizationManager) - cross-platform CLI for managing JSON (i18next compatible) and .resx localization files
 - [Fink](https://inlang.com/m/tdozzpar/app-inlang-editor) - git-based editor in the browser that connects to your repo
+- [WhisperSubTranslate](https://github.com/Blue-B/WhisperSubTranslate) - desktop app that generates translated subtitles from any video (whisper.cpp + local LLM or DeepL/OpenAI/Gemini)
 
 ## Text translation services
 - [DeepL](https://deepl.com) - text translation service


### PR DESCRIPTION
Adds [WhisperSubTranslate](https://github.com/Blue-B/WhisperSubTranslate) to Apps and extensions for translation management.

Desktop Electron app (GPL-3.0) that generates translated subtitles from any video file. Local speech-to-text via whisper.cpp, translation via local LLM (HY-MT GGUF, offline) or DeepL/OpenAI/Gemini with user keys. 14 target languages. Sits in the same category as RTranslator / Crow Translate / Argos Translate already in the list. Latest release v2.0.0.