### PR TITLE
Add ilingo (JavaScript / TypeScript libraries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [schummar-translate](https://github.com/schummar/schummar-translate) - TypeScript powered translation library for React and Node.js
 - [messageformat](https://github.com/messageformat/messageformat) - ICU MessageFormat for JavaScript, plural and gender capable messages
 - [rosetta](https://github.com/lukeed/rosetta) - A general purpose internationalization library in ~300 bytes (including dependencies)
+- [ilingo](https://ilingo.tada5hi.net) - framework-agnostic i18n core with pluggable stores, BCP-47 fallback and Intl-native plurals & formatters
 - (archived) [Intl.js](https://github.com/andyearnshaw/Intl.js) - implementation of the ECMAScript Internationalization API
 - (archived) [facebook/fbt](https://github.com/facebook/fbt) - i18n framework for JS/TS designed to be powerful, flexible, simple and intuitive
 


### PR DESCRIPTION
Adds **ilingo** to *📦 Libraries → JavaScript / TypeScript*.

ilingo is a lightweight (~6 kB), framework-agnostic i18n core for TypeScript: pluggable stores (memory / filesystem / lazy loader / custom), BCP-47 fallback chains, and `Intl`-native plurals & formatters. MIT-licensed, published on npm, docs at https://ilingo.tada5hi.net. (Disclosure: I maintain it.)

The entry follows the contributing rules: not paid/freemium, not AI-generated, under 150 chars, no trailing period, and it focuses on what's unique (pluggable stores + a framework-agnostic core that also runs on edge, browser and Vue) rather than a generic message.