### PR TITLE
Add arabicfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [schummar-translate](https://github.com/schummar/schummar-translate) - TypeScript powered translation library for React and Node.js
 - [messageformat](https://github.com/messageformat/messageformat) - ICU MessageFormat for JavaScript, plural and gender capable messages
 - [rosetta](https://github.com/lukeed/rosetta) - A general purpose internationalization library in ~300 bytes (including dependencies)
+- [arabicfmt](https://github.com/cc1a2b/arabicfmt) - arabic-first formatting: hijri dates, تفقيط number to words, 22 arab currencies, rtl/bidi fixes
 - (archived) [Intl.js](https://github.com/andyearnshaw/Intl.js) - implementation of the ECMAScript Internationalization API
 - (archived) [facebook/fbt](https://github.com/facebook/fbt) - i18n framework for JS/TS designed to be powerful, flexible, simple and intuitive
 


### PR DESCRIPTION
Adds arabicfmt to JavaScript / TypeScript.

Free & MIT, zero runtime dependencies, no paid service. Unique focus: Arabic-first formatting — Umm al-Qura hijri dates, تفقيط (number to words), currency for all 22 arab countries incl. the new saudi riyal sign U+20C1, rtl/bidi fixes. Entry kept short, lowercase, no trailing period per the contribution notes.